### PR TITLE
[NodeJS] Support CLI installation via NPM

### DIFF
--- a/nodejs/package.json.gen.js
+++ b/nodejs/package.json.gen.js
@@ -5,6 +5,9 @@ const common = {
   main: "index.node",
   types: "index.d.ts",
   files: ["postinstall.js", "index.d.ts"],
+  bin: {
+    "minify-html": "cli"
+  },
   scripts: {
     build: "node-gyp build && shx mv build/Release/index.node index.node",
     clean:

--- a/nodejs/postinstall.js
+++ b/nodejs/postinstall.js
@@ -5,10 +5,62 @@ const zlib = require("zlib");
 const pkg = require("./package.json");
 
 const MAX_DOWNLOAD_ATTEMPTS = 4;
+const BINARY_CMD = "minify-html";
 
-const binaryName = [process.platform, process.arch].join("__");
-const binaryPath = path.join(__dirname, "index.node");
+const { platform, arch } = process;
+const isWindows = platform === "win32";
+const isLinux = platform === "linux";
+const isMacOS = platform === "darwin";
+const binaryPaths = {
+  nodejs: path.join(__dirname, "index.node"),
+  cli: path.join(__dirname, "cli"),
+};
 
+const buildUrl = (target) => {
+  let url = 'https://wilsonl.in/minify-html/bin/';
+
+  if (target === 'nodejs') {
+    const binaryName = [platform, arch].join("__");
+    const file = `${binaryName}.node.gz`;
+
+    url += `/${target}/${pkg.version}/${pkg.name.split("/")[1]}/${file}`;
+  }
+  else if (target === 'cli') {
+    const os = isWindows
+      ? 'windows'
+      : isLinux
+      ? 'linux'
+      : isMacOS
+      ? 'macos'
+      : null;
+
+    if (os === null) {
+      console.warn(`[${pkg.name} CLI] Your OS (${os}) doesn\'t seem ` +
+        `to be supported yet. Running ${BINARY_CMD} might fail.`);
+    }
+
+    const fileExt = os === 'windows' ? '.exe' : '';
+    const fallbackArch = /x(?:86_)?64/.test(arch) ? 'x86_64' : null;
+
+    if (!fallbackArch) {
+      console.warn(`[${pkg.name} CLI] Your CPU architecture (${arch}) ` +
+        `is not supported yet. Running ${BINARY_CMD} might fail.`);
+    }
+    else if (fallbackArch !== arch) {
+      console.info(`[${pkg.name} CLI] Using ${fallbackArch} binary ` +
+        `as fallback for your CPU architecture (${arch}).`);
+    }
+
+    const file = `${pkg.version}-${os}-${fallbackArch}${fileExt}`;
+
+    url += `/${file}`;
+  }
+  else {
+    throw new RangeError(`${target} must be "nodejs", or "cli".`);
+  }
+
+  return url;
+};
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 class StatusError extends Error {
@@ -31,15 +83,11 @@ const fetch = (url) =>
     stream.on("error", reject);
   });
 
-const downloadNativeBinary = async () => {
+const downloadNativeBinary = async (url, destination, unzip) => {
   for (let attempt = 0; ; attempt++) {
     let binary;
     try {
-      binary = await fetch(
-        `https://wilsonl.in/minify-html/bin/nodejs/${pkg.version}/${
-          pkg.name.split("/")[1]
-        }/${binaryName}.node.gz`
-      );
+      binary = await fetch(url);
     } catch (e) {
       if (e instanceof StatusError && attempt < MAX_DOWNLOAD_ATTEMPTS) {
         await wait(Math.random() * 2500 + 500);
@@ -48,20 +96,47 @@ const downloadNativeBinary = async () => {
       throw e;
     }
 
-    fs.writeFileSync(binaryPath, zlib.gunzipSync(binary));
+    const fileContent = unzip
+      ? zlib.gunzipSync(binary)
+      : binary;
+
+    fs.writeFileSync(destination, fileContent);
     break;
   }
 };
 
-if (
-  !fs.existsSync(path.join(__dirname, ".no-postinstall")) &&
-  !fs.existsSync(binaryPath)
-) {
-  downloadNativeBinary().then(
-    () => console.log(`Downloaded ${pkg.name}`),
-    (err) => {
-      console.error(`Failed to download ${pkg.name}: ${err}`);
-      process.exit(1);
+/**
+ * Fetch multiple binaries at the same time.
+ * 
+ * @TODO  Consider downloading one file after another to prevent TOO_MANY_REQUESTS
+ *        server errors (if applicable).
+ */
+Promise.all(
+  Object.keys(binaryPaths).map(async (target) => {
+    const binaryPath = binaryPaths[target];
+
+    if (
+      !fs.existsSync(path.join(__dirname, ".no-postinstall")) &&
+      !fs.existsSync(binaryPath)
+    ) {
+      const url = buildUrl(target);
+      const isTargetingNodejs = target === 'nodejs';
+      const unzip = isTargetingNodejs;
+
+      return downloadNativeBinary(url, binaryPath, unzip).then(
+        () => console.log(`Downloaded the ${target} version of ${pkg.name}`),
+        (err) => {
+          console.error(`Failed to download the ${target} version of ${pkg.name}: ${err}`);
+          // Don't exit if the binary for the CLI is not downloaded.
+          if (isTargetingNodejs) {
+            process.exit(1);
+          }
+        }
+      );
     }
-  );
-}
+  })
+).then(() => {
+  console.log(`${pkg.name} was downloaded successfully.`);
+}).catch((err) => {
+  console.error(err);
+});


### PR DESCRIPTION
Hi, @wilsonzlin. I hope you're doing great!

I made some modifications to your code to allow downloading your Windows/MacOS/Linux binaries on postinstall, so that we could install your code via NPM, and use the CLI version (using the "minify-html" command) directly, without having to copy/update those binaries manually. That way, we simplify the usage of your CLI code using NPM, and avoid using a new file/wrapper to "require()" this module.

It would be awesome if you could (test it and) publish it!

Basically, one should be able to install using `npm install [at]minify-html/js` and then run `minify-html --help` from the CLI. *I tested it by copying the distributed files to a new folder, and linking it (using npm link), and it worked.*

Please, feel free to tell me if it works, if you want me to add something else, or if this change is actually required as I don't know if the index.node binary handles those CLI options...

Anyway, thank you for your time, and thank you for writing this project.

**Have a nice day!**