### PR TITLE
fix(cli): use rayon instead of handwritten thread pool

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 minify-html = { path = "../rust/main" }
 structopt = "0.3"
 rayon = "1.5"
+
 [profile.release]
 lto = true
 strip = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,10 +8,8 @@ edition = "2018"
 
 [dependencies]
 minify-html = { path = "../rust/main" }
-num_cpus = "1.13.1"
-spmc = "0.3.0"
 structopt = "0.3"
-
+rayon = "1.5"
 [profile.release]
 lto = true
 strip = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -155,6 +155,7 @@ fn main() {
                 out_file.write_all(&out_code),
                 "Could not save minified code"
             );
+            println!("finish minifying {}", input_name);
         });
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -97,7 +97,8 @@ fn main() {
         remove_processing_instructions: args.remove_processing_instructions,
     });
 
-    if args.inputs.is_empty() {
+    if args.inputs.len() <= 1 {
+        // single file mode or stdin mode
         let input_name = args
             .inputs
             .get(0)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -155,7 +155,7 @@ fn main() {
                 out_file.write_all(&out_code),
                 "Could not save minified code"
             );
-            println!("finish minifying {}", input_name);
+            println!("{}", input_name);
         });
     }
 }


### PR DESCRIPTION
The previous implementation of CLI is problematic. It will only format the first `num_cpu` files, other files will be discarded. Moreover, if the number of the files is less than `num_cpu`, it will stuck.

This PR use rayon(a popular data parallel library) to avoid hand-written thread pool.