### PR TITLE
Update Node snippet in README to use `Buffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ yarn add @minify-html/node
 TypeScript definitions are available.
 
 ```ts
+import { Buffer } from "node:buffer";
 import * as minifyHtml from "@minify-html/node";
 // Or `const minifyHtml = require("@minify-html/node")` if not using TS/ESM.
 
-const minified = minifyHtml.minify("<p>  Hello, world!  </p>", { keep_spaces_between_attributes: true, keep_comments: true });
+const minified = minifyHtml.minify(Buffer.from("<p>  Hello, world!  </p>"), { keep_spaces_between_attributes: true, keep_comments: true });
 ```
 
 All [`Cfg` fields](https://docs.rs/minify-html/latest/minify_html/struct.Cfg.html) are available as snake_case properties on the object provided as the second argument; if any are not set, they default to `false`.


### PR DESCRIPTION
From what I've gathered, the 0.9.x branch of `@minify-html/node` requires a `Buffer` argument.

Update the README to match.

As an aside, passing a string to `minify` gives a somewhat opaque Rust-specific error about downcast failure:

```
TypeError: failed to downcast any to Buffer
```