### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         variant: [main, onepass]
         os: [macos-11.0, ubuntu-18.04, windows-2019, self-hosted-linux-arm64]
-        python: [3.8, 3.9, '3.10']
+        python: [3.8, 3.9, '3.10', '3.11']
     steps:
       - uses: actions/checkout@v1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # minify-html changelog
 
+## Pending
+
+- [Python] Add Python 3.11 support.
+
 ## 0.10.2
 
 - Bump [minify-js](https://github.com/wilsonzlin/minify-js) to 0.2.6.

--- a/python/main/Cargo.toml
+++ b/python/main/Cargo.toml
@@ -17,5 +17,5 @@ crate-type = ["cdylib"]
 [dependencies]
 minify-html = { path = "../../rust/main" }
 [dependencies.pyo3]
-version = "0.13.0"
+version = "0.17.2"
 features = ["extension-module"]

--- a/python/onepass/Cargo.toml
+++ b/python/onepass/Cargo.toml
@@ -17,5 +17,5 @@ crate-type = ["cdylib"]
 [dependencies]
 minify-html-onepass = { path = "../../rust/onepass" }
 [dependencies.pyo3]
-version = "0.13.0"
+version = "0.17.2"
 features = ["extension-module"]


### PR DESCRIPTION
Python 3.11 was released yesterday: https://www.python.org/downloads/release/python-3110/

It has been added to GitHub Actions: https://github.com/actions/python-versions/pull/193

This PR updates PYO3 to the latest version per [its changelog](https://github.com/PyO3/pyo3/blob/main/CHANGELOG.md#0172---2022-10-04) and adds a Python 3.11 run to the release process.