### PR TITLE
nodejs: Make cargo-cp-artifact a dev dependency

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -40,11 +40,9 @@
     "node": ">= 8.6.0"
   },
   "homepage": "https://github.com/wilsonzlin/minify-html#readme",
-  "dependencies": {
-    "cargo-cp-artifact": "^0.1"
-  },
   "devDependencies": {
     "@types/node": "^14.6.0",
+    "cargo-cp-artifact": "^0.1.7",
     "shx": "^0.3.4"
   },
   "keywords": [


### PR DESCRIPTION
cargo-cp-artifact is only used in the 'build' npm run script which appears to be run as part of CI and packaging.

This change will remove cargo-cp-artifact as a transitive dependency to consumers of @minify-html/node.