### PR TITLE
Fix the detection of JS module scripts

### DIFF
--- a/rust/main/src/parse/element.rs
+++ b/rust/main/src/parse/element.rs
@@ -166,11 +166,11 @@ pub fn parse_element(code: &mut Code, ns: Namespace, parent: &[u8]) -> NodeData 
         children,
     } = match (ns, elem_name.as_slice()) {
         (_, b"script") => match attributes.get(b"type".as_ref()) {
-            Some(mime) if !JAVASCRIPT_MIME_TYPES.contains(mime.as_slice()) => {
-                parse_script_content(code, ScriptOrStyleLang::Data)
-            }
             Some(typ) if typ.as_slice() == b"module" => {
                 parse_script_content(code, ScriptOrStyleLang::JSModule)
+            }
+            Some(mime) if !JAVASCRIPT_MIME_TYPES.contains(mime.as_slice()) => {
+                parse_script_content(code, ScriptOrStyleLang::Data)
             }
             _ => parse_script_content(code, ScriptOrStyleLang::JS),
         },


### PR DESCRIPTION
The detection of JS modules was already present, but due to the ordering in the match statement, it was always overruled by the match arm for MIME types. Therefore, it was detected as _data_ rather than a module when minifying inline JS module scripts.
