### PR TITLE
Implement std::error::Error for Error and FriendlyError

### DIFF
--- a/rust/onepass/src/err.rs
+++ b/rust/onepass/src/err.rs
@@ -9,7 +9,7 @@ pub enum ErrorType {
 
 impl ErrorType {
     /// Generates an English message describing the error with any additional context.
-    pub fn message(self) -> String {
+    pub fn message(&self) -> String {
         match self {
             ErrorType::ClosingTagMismatch { expected, got } => {
                 format!(
@@ -37,6 +37,14 @@ pub struct Error {
     pub position: usize,
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.error_type.message())
+    }
+}
+
+impl std::error::Error for Error {}
+
 /// User-friendly details about a minification failure, including an English message description of
 /// the reason, and generated printable contextual representation of the code where the error
 /// occurred.
@@ -46,6 +54,14 @@ pub struct FriendlyError {
     pub message: String,
     pub code_context: String,
 }
+
+impl std::fmt::Display for FriendlyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for FriendlyError {}
 
 pub type ProcessingResult<T> = Result<T, ErrorType>;
 


### PR DESCRIPTION
This PR adds implementations of `std::error::Error` to both `Error` and `FriendlyError` in the onepass crate. The only missing requirement was an implementation of `Display`, which I added using the message from `ErrorType`.

 Implementing the `Error` trait is useful for when you want to return errors from a function and don't care about the exact error type. Personally, I ran into this issue while using this library with [anyhow](https://github.com/dtolnay/anyhow).