### PR TITLE
Add binary for Python 3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         variant: [main, onepass]
         os: [macos-11.0, ubuntu-20.04, windows-2019, self-hosted-linux-arm64]
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
On Python 3.12, minify-html currently needs to be built using cargo. This has a major impact for docker builds, see https://github.com/adamchainz/django-minify-html/issues/164#issuecomment-1856784591.

This change should address it.

Please also run the build script so the resulting binary gets published on PyPI.