### PR TITLE
Don't attempt to minify `script`/`style` tags with no content

### DIFF
--- a/minify-html/src/minify/content.rs
+++ b/minify-html/src/minify/content.rs
@@ -156,6 +156,7 @@ pub fn minify_content(
       ),
       NodeData::Instruction { code, ended } => minify_instruction(cfg, out, &code, ended),
       NodeData::RcdataContent { typ, text } => minify_rcdata(cfg, out, typ, &text),
+      NodeData::ScriptOrStyleContent { code, lang: _ } if code.is_empty() => {},
       NodeData::ScriptOrStyleContent { code, lang } => match lang {
         ScriptOrStyleLang::CSS => minify_css(cfg, out, &code),
         ScriptOrStyleLang::Data => out.extend_from_slice(&code),


### PR DESCRIPTION
This is more common with `script` tags, where most uses will reference external script files than inline scripts.

Skipping this, even when JS / CSS minification is enabled avoids the need to spin up the minification libraries entirly.

I've intentionally made the code change here, rather than where `ScriptOrStyleContent` is determined, as the code change was significantly smaller with the same effect.