### PR TITLE
Shrink output Vec to fit contents

### DIFF
--- a/minify-html/src/lib.rs
+++ b/minify-html/src/lib.rs
@@ -52,6 +52,7 @@ pub fn minify(src: &[u8], cfg: &Cfg) -> Vec<u8> {
     EMPTY_SLICE,
     parsed.children,
   );
+  out.shrink_to_fit();
   out
 }
 


### PR DESCRIPTION
Minified output should be smaller than input, so reclaim some memory.