### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,13 @@ jobs:
         os: [ubuntu-latest, macos-11.0, windows-2019]
         variant: ['', '-onepass']
         target: [x86_64, aarch64]
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python:
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
+        - '3.13'
         exclude:
           # Building for Windows aarch64 isn't ready yet.
           - os: windows-2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - BREAKING: Some entity minifications are now classified as "possibly noncompliant" and can be enabled via the `allow_optimal_entities` option but won't be performed by default.
 - [Internal] Migrate to [aHash](https://github.com/tkaitchuck/aHash/blob/master/compare/readme.md) for faster more consistent performance and once_cell for modern ergonomics.
 - [Node.js] Fix ARM64 package metadata.
+- [Python] Add Python 3.13 support.
 
 ## 0.15.0
 

--- a/minify-html-onepass-python/Cargo.toml
+++ b/minify-html-onepass-python/Cargo.toml
@@ -16,5 +16,5 @@ crate-type = ["cdylib"]
 [dependencies]
 minify-html-onepass = { path = "../minify-html-onepass" }
 [dependencies.pyo3]
-version = "0.17.2"
+version = "0.22.5"
 features = ["extension-module", "generate-import-lib"]

--- a/minify-html-python/Cargo.toml
+++ b/minify-html-python/Cargo.toml
@@ -16,5 +16,5 @@ crate-type = ["cdylib"]
 [dependencies]
 minify-html = { path = "../minify-html" }
 [dependencies.pyo3]
-version = "0.17.2"
+version = "0.22.5"
 features = ["extension-module", "generate-import-lib"]


### PR DESCRIPTION
Python 3.13 final release was October 7th: https://pythoninsider.blogspot.com/2024/10/python-3130-final-released.html

This PR adds support in two steps:

1. Upgrade PyO3, since version 0.22.0 added Python 3.13 support ([changelog](https://pyo3.rs/v0.22.5/changelog)).
2. Add 3.13 to the build matrix.

I copied these changes from past Python bump PRs: #117, #163.