### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,6 +35,7 @@ jobs:
         - '3.11'
         - '3.12'
         - '3.13'
+        - '3.14'
         exclude:
           # Building for Windows aarch64 isn't ready yet.
           - os: windows-2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [CLI] Add missing exit status on I/O errors.
 - [Internal] Loosen ahash dependency version.
 - [Internal] Bump lightningcss.
+- [Python] Add Python 3.14 support.
 
 ## 0.16.4
 

--- a/minify-html-onepass-python/Cargo.toml
+++ b/minify-html-onepass-python/Cargo.toml
@@ -15,4 +15,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 minify-html-onepass = { path = "../minify-html-onepass" }
-pyo3 = { "version" = "0.24.0", features = ["extension-module", "generate-import-lib"] }
+pyo3 = { "version" = "0.26.0", features = ["extension-module", "generate-import-lib"] }

--- a/minify-html-python/Cargo.toml
+++ b/minify-html-python/Cargo.toml
@@ -15,4 +15,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 minify-html = { path = "../minify-html" }
-pyo3 = { "version" = "0.24.0", features = ["extension-module", "generate-import-lib"] }
+pyo3 = { "version" = "0.26.0", features = ["extension-module", "generate-import-lib"] }


### PR DESCRIPTION
Copying #205 for this year’s version of Python. Since Python 3.14 is in the release candidate phase, it's safe to build and release wheels compiled against it, as the ABI is guaranteed stable for the final release.