### PR TITLE
Add `always_quote_attr_values` option.

### DIFF
--- a/minhtml/src/main.rs
+++ b/minhtml/src/main.rs
@@ -26,6 +26,10 @@ struct Cli {
   #[structopt(short, long, parse(from_os_str))]
   output: Option<std::path::PathBuf>,
 
+  /// Always quote attribute values.
+  #[structopt(long)]
+  always_quote_attribute_values: bool,
+
   /// Allow unquoted attribute values in the output to contain characters prohibited by the [WHATWG specification](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2). These will still be parsed correctly by almost all browsers.
   #[structopt(long)]
   allow_noncompliant_unquoted_attribute_values: bool,
@@ -113,6 +117,7 @@ fn main() {
 
   #[rustfmt::skip]
   let cfg = Arc::new(Cfg {
+    always_quote_attribute_values: args.always_quote_attribute_values,
     allow_noncompliant_unquoted_attribute_values: args.allow_noncompliant_unquoted_attribute_values,
     allow_optimal_entities: args.allow_optimal_entities,
     allow_removing_spaces_between_attributes: args.allow_removing_spaces_between_attributes,

--- a/minify-html-java/src/main/java/in/wilsonl/minifyhtml/Configuration.java
+++ b/minify-html-java/src/main/java/in/wilsonl/minifyhtml/Configuration.java
@@ -6,6 +6,7 @@ package in.wilsonl.minifyhtml;
  * Class representing minification configuration.
  */
 public class Configuration {
+  public final boolean always_quote_attribute_values;
   public final boolean allow_noncompliant_unquoted_attribute_values;
   public final boolean allow_optimal_entities;
   public final boolean allow_removing_spaces_between_attributes;
@@ -23,6 +24,7 @@ public class Configuration {
   public final boolean remove_processing_instructions;
 
   private Configuration(
+    boolean always_quote_attribute_values,
     boolean allow_noncompliant_unquoted_attribute_values,
     boolean allow_optimal_entities,
     boolean allow_removing_spaces_between_attributes,
@@ -39,6 +41,7 @@ public class Configuration {
     boolean remove_bangs,
     boolean remove_processing_instructions
   ) {
+    this.always_quote_attribute_values = always_quote_attribute_values;
     this.allow_noncompliant_unquoted_attribute_values = allow_noncompliant_unquoted_attribute_values;
     this.allow_optimal_entities = allow_optimal_entities;
     this.allow_removing_spaces_between_attributes = allow_removing_spaces_between_attributes;
@@ -60,6 +63,7 @@ public class Configuration {
    * Builder to help create configuration.
    */
   public static class Builder {
+    private boolean always_quote_attribute_values = false;
     private boolean allow_noncompliant_unquoted_attribute_values = false;
     private boolean allow_optimal_entities = false;
     private boolean allow_removing_spaces_between_attributes = false;
@@ -76,6 +80,10 @@ public class Configuration {
     private boolean remove_bangs = false;
     private boolean remove_processing_instructions = false;
 
+    public Builder setAlwaysQuoteAttributeValues(boolean v) {
+      this.always_quote_attribute_values = v;
+      return this;
+    }
     public Builder setAllowNoncompliantUnquotedAttributeValues(boolean v) {
       this.allow_noncompliant_unquoted_attribute_values = v;
       return this;
@@ -139,6 +147,7 @@ public class Configuration {
 
     public Configuration build() {
       return new Configuration(
+        this.always_quote_attribute_values,
         this.allow_noncompliant_unquoted_attribute_values,
         this.allow_optimal_entities,
         this.allow_removing_spaces_between_attributes,

--- a/minify-html-java/src/main/rust/lib.rs
+++ b/minify-html-java/src/main/rust/lib.rs
@@ -11,6 +11,7 @@ fn build_cfg(env: &JNIEnv, obj: &JObject) -> Cfg {
   #[rustfmt::skip]
   // This is a statement because "attributes on expressions are experimental".
   let cfg = Cfg {
+    always_quote_attribute_values: env.get_field(*obj, "always_quote_attribute_values", "Z").unwrap().z().unwrap(),
     allow_noncompliant_unquoted_attribute_values: env.get_field(*obj, "allow_noncompliant_unquoted_attribute_values", "Z").unwrap().z().unwrap(),
     allow_optimal_entities: env.get_field(*obj, "allow_optimal_entities", "Z").unwrap().z().unwrap(),
     allow_removing_spaces_between_attributes: env.get_field(*obj, "allow_removing_spaces_between_attributes", "Z").unwrap().z().unwrap(),

--- a/minify-html-nodejs/index.d.ts
+++ b/minify-html-nodejs/index.d.ts
@@ -8,6 +8,8 @@
 export function minify(
   src: Buffer,
   cfg: {
+    /** Always quote attribute values in the output. */
+    always_quote_attribute_values?: boolean;
     /** Allow unquoted attribute values in the output to contain characters prohibited by the [WHATWG specification](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2). These will still be parsed correctly by almost all browsers. */
     allow_noncompliant_unquoted_attribute_values?: boolean;
     /** Allow some minifications around entities that may not pass validation, but will still be parsed correctly by almost all browsers. */

--- a/minify-html-nodejs/src/lib.rs
+++ b/minify-html-nodejs/src/lib.rs
@@ -19,6 +19,7 @@ fn minify(mut cx: FunctionContext) -> JsResult<JsBuffer> {
   };
   #[rustfmt::skip]
   let cfg = minify_html::Cfg {
+    always_quote_attribute_values: get_bool!(cx, opt, "always_quote_attribute_values"),
     allow_noncompliant_unquoted_attribute_values: get_bool!(cx, opt, "allow_noncompliant_unquoted_attribute_values"),
     allow_optimal_entities: get_bool!(cx, opt, "allow_optimal_entities"),
     allow_removing_spaces_between_attributes: get_bool!(cx, opt, "allow_removing_spaces_between_attributes"),

--- a/minify-html-python/minify_html.pyi
+++ b/minify-html-python/minify_html.pyi
@@ -1,5 +1,6 @@
 def minify(
     code: str,
+    always_quote_attribute_values: bool = False,
     allow_noncompliant_unquoted_attribute_values: bool = False,
     allow_optimal_entities: bool = False,
     allow_removing_spaces_between_attributes: bool = False,

--- a/minify-html-python/src/lib.rs
+++ b/minify-html-python/src/lib.rs
@@ -10,6 +10,7 @@ use std::string::String;
   signature = (
     code,
     *,
+    always_quote_attribute_values = true,
     allow_noncompliant_unquoted_attribute_values = false,
     allow_optimal_entities = false,
     allow_removing_spaces_between_attributes = false,
@@ -29,6 +30,7 @@ use std::string::String;
 )]
 fn minify(
   code: String,
+  always_quote_attribute_values: bool,
   allow_noncompliant_unquoted_attribute_values: bool,
   allow_optimal_entities: bool,
   allow_removing_spaces_between_attributes: bool,
@@ -47,6 +49,7 @@ fn minify(
 ) -> String {
   let code = code.into_bytes();
   let out_code = minify_html_native(&code, &Cfg {
+    always_quote_attribute_values,
     allow_noncompliant_unquoted_attribute_values,
     allow_optimal_entities,
     allow_removing_spaces_between_attributes,

--- a/minify-html-ruby/ext/minify_html/src/lib.rs
+++ b/minify-html-ruby/ext/minify_html/src/lib.rs
@@ -8,6 +8,7 @@ use minify_html::Cfg as CfgNative;
 fn minify_html(source: String, cfg: RHash) -> String {
   #[rustfmt::skip]
   let out_code = minify_html_native(source.as_bytes(), &CfgNative {
+    always_quote_attribute_values: cfg.aref(StaticSymbol::new("always_quote_attribute_values")).unwrap_or_default(),
     allow_noncompliant_unquoted_attribute_values: cfg.aref(StaticSymbol::new("allow_noncompliant_unquoted_attribute_values")).unwrap_or_default(),
     allow_optimal_entities: cfg.aref(StaticSymbol::new("allow_optimal_entities")).unwrap_or_default(),
     allow_removing_spaces_between_attributes: cfg.aref(StaticSymbol::new("allow_removing_spaces_between_attributes")).unwrap_or_default(),

--- a/minify-html-wasm/src/lib.rs
+++ b/minify-html-wasm/src/lib.rs
@@ -22,6 +22,7 @@ macro_rules! get_prop {
 pub fn minify(code: &[u8], cfg: &JsValue) -> Vec<u8> {
   #[rustfmt::skip]
   let cfg = minify_html::Cfg {
+    always_quote_attribute_values: get_prop!(cfg, "always_quote_attribute_values"),
     allow_noncompliant_unquoted_attribute_values: get_prop!(cfg, "allow_noncompliant_unquoted_attribute_values"),
     allow_optimal_entities: get_prop!(cfg, "allow_optimal_entities"),
     allow_removing_spaces_between_attributes: get_prop!(cfg, "allow_removing_spaces_between_attributes"),

--- a/minify-html/src/cfg/mod.rs
+++ b/minify-html/src/cfg/mod.rs
@@ -2,6 +2,8 @@
 /// minification approach.
 #[derive(Clone, Default)]
 pub struct Cfg {
+  /// Always quote attribute values in the output.
+  pub always_quote_attribute_values: bool,
   /// Allow unquoted attribute values in the output to contain characters prohibited by the [WHATWG specification](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2). These will still be parsed correctly by almost all browsers.
   pub allow_noncompliant_unquoted_attribute_values: bool,
   /// Allow some minifications around entities that may not pass validation, but will still be parsed correctly by almost all browsers.

--- a/minify-html/src/minify/attr.rs
+++ b/minify-html/src/minify/attr.rs
@@ -456,13 +456,15 @@ pub fn minify_attr(
   if sq.len() < min.len() {
     min = sq;
   };
-  let uq = encode_unquoted(
-    &encoded,
-    must_end_with_semicolon,
-    !cfg.allow_noncompliant_unquoted_attribute_values,
-  );
-  if uq.len() < min.len() {
-    min = uq;
-  };
+  if !cfg.always_quote_attribute_values {
+    let uq = encode_unquoted(
+      &encoded,
+      must_end_with_semicolon,
+      !cfg.allow_noncompliant_unquoted_attribute_values,
+    );
+    if uq.len() < min.len() {
+      min = uq;
+    };
+  }
   AttrMinified::Value(min)
 }


### PR DESCRIPTION
Fixes #233 by adding a new `always_quote_attr_values` option. The default behavior remains the same -- when the option isn't specified, attribute values will be unquoted when possible.

I'm personally interested in having this option available because I'd like to use this library to minify HTML for emails, and I'm not confident that unquoted attributes will be handled well across all email clients.