### PR TITLE
Add support to preserve self-closing syntax on custom HTML elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 - Disable treeshake annotations (e.g., `/*#__PURE__*/`) in minified JavaScript output as they are only useful for bundlers, not inline scripts.
+- Add `preserve_self_closing_on_unknown_tags` option to preserve self-closing syntax on unknown HTML elements.
 
 ## 0.18.1
 

--- a/minify-html-common/src/spec/tag/whitespace.rs
+++ b/minify-html-common/src/spec/tag/whitespace.rs
@@ -58,7 +58,7 @@ static DEFAULT_SVG: &WhitespaceMinification = &WhitespaceMinification {
   trim: true,
 };
 
-static HTML_TAG_WHITESPACE_MINIFICATION: Lazy<
+pub static HTML_TAG_WHITESPACE_MINIFICATION: Lazy<
   AHashMap<&'static [u8], &'static WhitespaceMinification>,
 > = Lazy::new(|| {
   let mut m = AHashMap::<&'static [u8], &'static WhitespaceMinification>::default();

--- a/minify-html/src/cfg/mod.rs
+++ b/minify-html/src/cfg/mod.rs
@@ -28,6 +28,8 @@ pub struct Cfg {
   pub preserve_brace_template_syntax: bool,
   /// When `<%` is seen in content, all source code until the subsequent matching closing `%>` gets piped through untouched.
   pub preserve_chevron_percent_template_syntax: bool,
+  /// Preserve self-closing syntax on unknown HTML elements (e.g. `<custom />`).
+  pub preserve_self_closing_on_unknown_tags: bool,
   /// Remove all bangs.
   pub remove_bangs: bool,
   /// Remove all processing instructions.

--- a/minify-html/src/lib.rs
+++ b/minify-html/src/lib.rs
@@ -42,7 +42,7 @@ pub fn minify(src: &[u8], cfg: &Cfg) -> Vec<u8> {
     treat_brace_as_opaque: cfg.preserve_brace_template_syntax,
     treat_chevron_percent_as_opaque: cfg.preserve_chevron_percent_template_syntax,
   });
-  let parsed = parse_content(&mut code, Namespace::Html, EMPTY_SLICE, EMPTY_SLICE);
+  let parsed = parse_content(cfg, &mut code, Namespace::Html, EMPTY_SLICE, EMPTY_SLICE);
   let mut out = Vec::with_capacity(src.len());
   minify_content(
     cfg,
@@ -58,7 +58,8 @@ pub fn minify(src: &[u8], cfg: &Cfg) -> Vec<u8> {
 
 pub fn canonicalise<T: Write>(out: &mut T, src: &[u8]) -> std::io::Result<()> {
   let mut code = Code::new(src);
-  let parsed = parse_content(&mut code, Namespace::Html, EMPTY_SLICE, EMPTY_SLICE);
+  let cfg = Cfg::new();
+  let parsed = parse_content(&cfg, &mut code, Namespace::Html, EMPTY_SLICE, EMPTY_SLICE);
   for c in parsed.children {
     c14n_serialise_ast(out, &c)?;
   }

--- a/minify-html/src/parse/content.rs
+++ b/minify-html/src/parse/content.rs
@@ -1,4 +1,5 @@
 use crate::ast::NodeData;
+use crate::cfg::Cfg;
 use crate::entity::decode::decode_entities;
 use crate::parse::bang::parse_bang;
 use crate::parse::comment::parse_comment;
@@ -169,6 +170,7 @@ pub struct ParsedContent {
 
 // Use empty slice for `grandparent` or `parent` if none.
 pub fn parse_content(
+  cfg: &Cfg,
   code: &mut Code,
   ns: Namespace,
   grandparent: &[u8],
@@ -228,7 +230,7 @@ pub fn parse_content(
     };
     match typ {
       Text => break,
-      OpeningTag => nodes.push(parse_element(code, ns, parent)),
+      OpeningTag => nodes.push(parse_element(cfg, code, ns, parent)),
       ClosingTag => {
         closing_tag_omitted = false;
         break;

--- a/minify-html/src/parse/tests/element.rs
+++ b/minify-html/src/parse/tests/element.rs
@@ -1,6 +1,7 @@
 use crate::ast::AttrVal;
 use crate::ast::ElementClosingTag;
 use crate::ast::NodeData;
+use crate::cfg::Cfg;
 use crate::parse::element::parse_element;
 use crate::parse::element::parse_tag;
 use crate::parse::element::ParsedTag;
@@ -52,7 +53,8 @@ fn test_parse_tag() {
 #[test]
 fn test_parse_element() {
   let mut code = Code::new(br#"<a b=\"c\"></a>"#);
-  let elem = parse_element(&mut code, Namespace::Html, EMPTY_SLICE);
+  let cfg = Cfg::new();
+  let elem = parse_element(&cfg, &mut code, Namespace::Html, EMPTY_SLICE);
   assert_eq!(elem, NodeData::Element {
     attributes: {
       let mut map = AHashMap::<Vec<u8>, AttrVal>::default();

--- a/minify-html/src/tests/mod.rs
+++ b/minify-html/src/tests/mod.rs
@@ -232,3 +232,21 @@ fn test_style_attr_minification() {
   // `style` attributes are removed if fully minified away.
   eval_with_css_min(br#"<div style="  /*  */   "></div>"#, br#"<div></div>"#);
 }
+
+#[test]
+fn test_preserve_self_closing_on_unknown_tags() {
+  let mut cfg = Cfg::new();
+  cfg.preserve_self_closing_on_unknown_tags = true;
+  eval_with_cfg(b"<custom />", b"<custom/>", &cfg);
+  eval_with_cfg(b"<custom class=\"foo\" />", b"<custom class=foo />", &cfg);
+  eval_with_cfg(b"<custom-element />", b"<custom-element/>", &cfg);
+  eval_with_cfg(b"<my-component />", b"<my-component/>", &cfg);
+  eval_with_cfg(b"<div />", b"<div>", &cfg);
+  eval_with_cfg(b"<div id=\"test\" />", b"<div id=test>", &cfg);
+  eval_with_cfg(b"<span />", b"<span>", &cfg);
+  eval_with_cfg(b"<input />", b"<input>", &cfg);
+  eval_with_cfg(b"<br />", b"<br>", &cfg);
+  eval_with_cfg(b"<img />", b"<img>", &cfg);
+  eval_with_cfg(b"<svg><path /></svg>", b"<svg><path/></svg>", &cfg);
+  eval_with_cfg(b"<svg><circle /></svg>", b"<svg><circle/></svg>", &cfg);
+}


### PR DESCRIPTION
We have a problem where we have to minify HTML that contain custom components, and these components are processed by other systems.

Introduce a new flag, `preserve_self_closing_on_unknown_tags`. When set, it preserves self-closing of all unknown tags, allowing them to preserve that attribute as they are processed by this minifier. Otherwise we do the standards compliant minification as normal.

I'm not particularly happy about how this reuses `HTML_TAG_WHITESPACE_MINIFICATION`. I'm open to suggestions on how to improve that, but it does allow us to move forward with a patch internally..

Fixes #257