### PR TITLE
Sort iteration for reproducible builds

### DIFF
--- a/minify-html-common/build.rs
+++ b/minify-html-common/build.rs
@@ -125,7 +125,10 @@ fn gen_attrs_rs(html_data: &HtmlData) -> String {
       let mut m = AHashMap::<&'static [u8], ByNamespace>::default();
   "#.to_string();
 
-  for (attr_name, namespaces) in html_data.attributes.iter() {
+  let mut attr_names: Vec<_> = html_data.attributes.keys().collect();
+  attr_names.sort();
+  for attr_name in attr_names {
+    let namespaces = &html_data.attributes[attr_name];
     write!(&mut code, r#"m.insert(b"{attr_name}", ByNamespace {{"#).unwrap();
     {
       for ns in [HtmlDataNamespace::Html, HtmlDataNamespace::Svg] {
@@ -153,7 +156,10 @@ fn gen_attrs_rs(html_data: &HtmlData) -> String {
                 "#
               )
               .unwrap();
-              for (tag_name, tag_attr) in tags_map {
+              let mut tag_names: Vec<_> = tags_map.keys().collect();
+              tag_names.sort();
+              for tag_name in tag_names {
+                let tag_attr = &tags_map[tag_name];
                 write!(
                   &mut code,
                   r#"m.insert(b"{}", {});"#,
@@ -493,7 +499,9 @@ fn gen_entities_rs() -> String {
     "EntityType::Hex".to_string(),
   );
   let mut shorter_encoded_entities = vec![];
-  for (encoded, entity) in entities {
+  let mut sorted_entities: Vec<_> = entities.into_iter().collect();
+  sorted_entities.sort_by(|(a, _), (b, _)| a.cmp(b));
+  for (encoded, entity) in sorted_entities {
     let val = format!(r#"&{:?}"#, entity.characters.as_bytes());
     trie_builder.add(
       encoded


### PR DESCRIPTION
Sort iteration for reproducible builds
because `HashMap` uses random seeds to counter DoS attacks, iteration order varied in every run, which made generated attrs.rs and entities.rs non-deterministic.

See https://reproducible-builds.org/ for why this matters.

This patch was done while working on reproducible builds for openSUSE.