### PR TITLE
Preserve template syntax when parsing element tags

### DIFF
--- a/minify-html/src/parse/element.rs
+++ b/minify-html/src/parse/element.rs
@@ -104,7 +104,6 @@ pub fn parse_tag(code: &mut Code) -> ParsedTag {
         loop {
           attr_name.extend_from_slice(code.slice_and_shift_while_not_seq_case_insensitive(closing));
 
-          // the template syntax closing word should be followed by a whitespace or the end of the tag (i.e. '>' or '/>')
           match code.shift_if_next_not_in_lookup(WHITESPACE_OR_SLASH_OR_EQUALS_OR_RIGHT_CHEVRON) {
             Some(c) => attr_name.push(c),
             None => break,

--- a/minify-html/src/parse/element.rs
+++ b/minify-html/src/parse/element.rs
@@ -24,6 +24,7 @@ use minify_html_common::spec::tag::ns::Namespace;
 use minify_html_common::spec::tag::void::VOID_TAGS;
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::io::Write;
 use std::str::from_utf8;
 
 fn parse_tag_name(code: &mut Code) -> Vec<u8> {
@@ -80,15 +81,46 @@ pub fn parse_tag(code: &mut Code) -> ParsedTag {
       break;
     };
     let mut attr_name = Vec::new();
-    // An attribute name can start with `=`, but ends at the next whitespace, `=`, `/`, or `>`.
-    if let Some(c) = code.shift_if_next_not_in_lookup(WHITESPACE_OR_SLASH) {
-      attr_name.push(c);
-    };
-    attr_name.extend_from_slice(
-      code.slice_and_shift_while_not_in_lookup(WHITESPACE_OR_SLASH_OR_EQUALS_OR_RIGHT_CHEVRON),
-    );
-    debug_assert!(!attr_name.is_empty());
-    attr_name.make_ascii_lowercase();
+
+    // preserve template passthrough behavior in tags
+    let mut template_enclosures = Vec::new();
+
+    if code.opts.treat_brace_as_opaque {
+      template_enclosures.extend_from_slice(&[
+        ("{{ ".as_bytes(), "}} ".as_bytes()),
+        ("{% ".as_bytes(), "%} ".as_bytes()),
+        ("{# ".as_bytes(), "#} ".as_bytes()),
+      ]);
+    }
+
+    if code.opts.treat_chevron_percent_as_opaque {
+      template_enclosures.push(("<% ".as_bytes(), "%> ".as_bytes()));
+    }
+
+    let mut template_attr_name = false;
+    for (opening, closing) in template_enclosures {
+      if code.shift_if_next_seq_case_insensitive(opening) {
+        let _ = attr_name.write(opening);
+        let rem = code.slice_and_shift_while_not_seq_case_insensitive(closing);
+        attr_name.extend_from_slice(&rem[..rem.len() - 1]); // skip the whitespace at the end
+        template_attr_name = true;
+        break;
+      }
+    }
+
+    if !template_attr_name {
+      // An attribute name can start with `=`, but ends at the next whitespace, `=`, `/`, or `>`.
+      if let Some(c) = code.shift_if_next_not_in_lookup(WHITESPACE_OR_SLASH) {
+        attr_name.push(c);
+      }
+
+      attr_name.extend_from_slice(
+        code.slice_and_shift_while_not_in_lookup(WHITESPACE_OR_SLASH_OR_EQUALS_OR_RIGHT_CHEVRON),
+      );
+      debug_assert!(!attr_name.is_empty());
+      attr_name.make_ascii_lowercase();
+    }
+
     // See comment for WHITESPACE_OR_SLASH in codepoints.ts for details of complex attr parsing.
     code.shift_while_in_lookup(WHITESPACE);
     let has_value = code.shift_if_next(b'=');

--- a/minify-html/src/parse/element.rs
+++ b/minify-html/src/parse/element.rs
@@ -87,22 +87,29 @@ pub fn parse_tag(code: &mut Code) -> ParsedTag {
 
     if code.opts.treat_brace_as_opaque {
       template_enclosures.extend_from_slice(&[
-        ("{{ ".as_bytes(), "}} ".as_bytes()),
-        ("{% ".as_bytes(), "%} ".as_bytes()),
-        ("{# ".as_bytes(), "#} ".as_bytes()),
+        ("{{".as_bytes(), "}}".as_bytes()),
+        ("{%".as_bytes(), "%}".as_bytes()),
+        ("{#".as_bytes(), "#}".as_bytes()),
       ]);
     }
 
     if code.opts.treat_chevron_percent_as_opaque {
-      template_enclosures.push(("<% ".as_bytes(), "%> ".as_bytes()));
+      template_enclosures.push(("<%".as_bytes(), "%>".as_bytes()));
     }
 
     let mut template_attr_name = false;
     for (opening, closing) in template_enclosures {
       if code.shift_if_next_seq_case_insensitive(opening) {
         let _ = attr_name.write(opening);
-        let rem = code.slice_and_shift_while_not_seq_case_insensitive(closing);
-        attr_name.extend_from_slice(&rem[..rem.len() - 1]); // skip the whitespace at the end
+        loop {
+          attr_name.extend_from_slice(code.slice_and_shift_while_not_seq_case_insensitive(closing));
+
+          // the template syntax closing word should be followed by a whitespace or the end of the tag (i.e. '>' or '/>')
+          match code.shift_if_next_not_in_lookup(WHITESPACE_OR_SLASH_OR_EQUALS_OR_RIGHT_CHEVRON) {
+            Some(c) => attr_name.push(c),
+            None => break,
+          }
+        }
         template_attr_name = true;
         break;
       }

--- a/minify-html/src/parse/mod.rs
+++ b/minify-html/src/parse/mod.rs
@@ -157,6 +157,26 @@ impl<'c> Code<'c> {
     last
   }
 
+  pub fn slice_and_shift_while_not_seq_case_insensitive(&mut self, seq: &[u8]) -> &[u8] {
+    let mut len = 0;
+    let mut internal_next = self.next;
+
+    loop {
+      if self
+        .code
+        .get(internal_next..internal_next + seq.len())
+        .filter(|n| n.eq_ignore_ascii_case(seq))
+        .is_some()
+      {
+        break;
+      }
+
+      len += 1;
+      internal_next += 1;
+    }
+    self.slice_and_shift(len + seq.len())
+  }
+
   pub fn rem(&self) -> usize {
     self.code.len() - self.next
   }

--- a/minify-html/src/parse/mod.rs
+++ b/minify-html/src/parse/mod.rs
@@ -162,17 +162,19 @@ impl<'c> Code<'c> {
     let mut internal_next = self.next;
 
     loop {
-      if self
-        .code
-        .get(internal_next..internal_next + seq.len())
-        .filter(|n| n.eq_ignore_ascii_case(seq))
-        .is_some()
-      {
-        break;
-      }
+      match self.code.get(internal_next..internal_next + seq.len()) {
+        Some(n) if !n.eq_ignore_ascii_case(seq) => {
+          len += 1;
+          internal_next += 1;
+        }
+        None => {
+          // prevent out-of-range panic in slice_and_shift()
+          len = len.min(self.rem() - seq.len());
 
-      len += 1;
-      internal_next += 1;
+          break;
+        }
+        _ => break,
+      }
     }
     self.slice_and_shift(len + seq.len())
   }


### PR DESCRIPTION
This pull request fixes #232 and #183 by allowing template syntax to be parsed as attribute names.