### PR TITLE
feat: add Ruby 4.0 support and drop unmaintained versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Ruby and Rust
       uses: oxidize-rb/actions/setup-ruby-and-rust@main
       with:
-        ruby-version: "3.4"
+        ruby-version: "4.0"
         bundler-cache: false
         cargo-cache: true
         cargo-vendor: true
@@ -56,7 +56,7 @@ jobs:
       uses: oxidize-rb/actions/cross-gem@v1
       with:
         platform: ${{ matrix.platform }}
-        ruby-versions: "2.7,3.0,3.1,3.2,3.3,3.4"
+        ruby-versions: "3.3,3.4,4.0"
         working-directory: ./minify-html-ruby
 
     - name: Publish gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 - Disable treeshake annotations (e.g., `/*#__PURE__*/`) in minified JavaScript output as they are only useful for bundlers, not inline scripts.
+- [Ruby] Add Ruby 4.0 support. Drop unmaintained Ruby 2.7, 3.0, 3.1, and 3.2.
 
 ## 0.18.1
 


### PR DESCRIPTION
This PR adds Ruby 4.0 to the build matrix and removes versions that have reached end of life (2.7, 3.0, 3.1, 3.2).

Changes:

 - Add 4.0 to the cross-compile ruby-versions list
 - Update the setup step to use Ruby 4.0 as the build tooling version
 - Remove 2.7, 3.0, 3.1, and 3.2 from the ruby-versions list
 - Update CHANGELOG.md